### PR TITLE
Parse errors to not include traces

### DIFF
--- a/lib/minitest_ext/exercism_reporter.rb
+++ b/lib/minitest_ext/exercism_reporter.rb
@@ -33,7 +33,15 @@ module MiniTest
     end
 
     def exception_raised!(e)
-      WriteReport.(path, :error, message: e.full_message)
+      message = 
+        if e.is_a?(SyntaxError)
+          "Line #{e.message.split(":").tap(&:shift).join(":")}"
+        else
+          line = e.backtrace_locations.first.to_s.split(":")[1]
+          "Line #{line}: #{e.message} (#{e.class.name})"
+        end
+
+      WriteReport.(path, :error, message: message)
     end
 
     private

--- a/test/fixtures/syntax_error_in_code/input/two_fer.rb
+++ b/test/fixtures/syntax_error_in_code/input/two_fer.rb
@@ -1,2 +1,2 @@
 module TwoFer
-end,,,,,,
+end,A stray comma

--- a/test/fixtures/syntax_error_in_tests/input/two_fer_test.rb
+++ b/test/fixtures/syntax_error_in_tests/input/two_fer_test.rb
@@ -1,3 +1,3 @@
 require 'minitest/autorun'
 
-,,,,,,,
+,This is a comma

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -30,8 +30,7 @@ class TestRunnerTest < Minitest::Test
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal "error", actual["status"]
 
-      assert actual['message'].include?(%q{undefined local variable or method `raise_an_error_because_i_am_a_random_method' for main:Object (NameError)})
-      assert actual['message'].include?(%Q{\n\tfrom bin/run.rb:3:in `<main>'\n})
+      assert_equal %q{Line 3: undefined local variable or method `raise_an_error_because_i_am_a_random_method' for main:Object (NameError)}, actual['message']
     end
   end
 
@@ -39,9 +38,13 @@ class TestRunnerTest < Minitest::Test
     with_tmp_dir_for_fixture(:syntax_error_in_tests) do |input_dir, output_dir|
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal "error", actual["status"]
+      expected = <<EOS
+Line 3: syntax error, unexpected ',', expecting end-of-input
+,This is a comma
+^
+EOS
 
-      assert actual['message'].include?(%q{expecting end-of-input (SyntaxError)})
-      assert actual['message'].include?(%Q{\n\tfrom bin/run.rb:3:in `<main>'\n})
+      assert_equal expected.strip, actual['message']
     end
   end
 
@@ -50,8 +53,12 @@ class TestRunnerTest < Minitest::Test
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal "error", actual["status"]
 
-      assert actual['message'].include?(%q{expecting end-of-input (SyntaxError)})
-      assert actual['message'].include?(%Q{\n\tfrom bin/run.rb:3:in `<main>'\n})
+      expected = <<EOS
+Line 2: syntax error, unexpected ',', expecting end-of-input
+end,A stray comma
+   ^
+EOS
+      assert_equal expected.strip, actual['message']
     end
   end
 end


### PR DESCRIPTION
This shows nice errors without traces, but still having the line number.

@kotp This incorporates your suggestions about being more explicit about the error being an error.