### PR TITLE
Add stripped tracebacks

### DIFF
--- a/lib/minitest_ext/extract_failure_error_message.rb
+++ b/lib/minitest_ext/extract_failure_error_message.rb
@@ -1,0 +1,25 @@
+class ExtractFailureErrorMessage
+  include Mandate
+
+  initialize_with :failure
+
+  def call
+    message
+  end
+
+  memoize
+  def message
+    parts = failure.message.split("\n")
+    err_msg = parts.shift
+    trace = parts.select {|line| line.include?(solution_filepath) }.
+                     map {|line| line.gsub("#{solution_filepath}:", "Line ") }.
+                     join("\n")
+    "#{err_msg}\n\nTraceback (most recent call first):\n#{trace}"
+
+  end
+
+  memoize
+  def solution_filepath
+    failure.location.split(":").first
+  end
+end

--- a/lib/minitest_ext/extract_standard_exception_error_message.rb
+++ b/lib/minitest_ext/extract_standard_exception_error_message.rb
@@ -1,0 +1,13 @@
+class ExtractStandardExceptionErrorMessage
+  include Mandate
+
+  initialize_with :exception
+
+  def call
+    "Line #{line_number}: #{exception.message} (#{exception.class.name})"
+  end
+
+  def line_number
+    exception.backtrace_locations.first.to_s.split(":")[1]
+  end
+end

--- a/lib/minitest_ext/extract_syntax_exception_error_message.rb
+++ b/lib/minitest_ext/extract_syntax_exception_error_message.rb
@@ -1,0 +1,9 @@
+class ExtractSyntaxExceptionErrorMessage
+  include Mandate
+
+  initialize_with :exception
+
+  def call
+    "Line #{exception.message.split(":").tap(&:shift).join(":")}"
+  end
+end

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -6,6 +6,10 @@ require "minitest/autorun"
 
 require_relative "write_report"
 
+require_relative "minitest_ext/extract_standard_exception_error_message"
+require_relative "minitest_ext/extract_syntax_exception_error_message"
+require_relative "minitest_ext/extract_failure_error_message"
+
 require_relative "minitest_ext/exercism_plugin"
 require_relative "minitest_ext/exercism_reporter"
 require_relative "minitest_ext/minitest"

--- a/test/fixtures/deep_exception/input/two_fer.rb
+++ b/test/fixtures/deep_exception/input/two_fer.rb
@@ -1,0 +1,10 @@
+module TwoFer
+  def self.two_fer(name = nil)
+    "One for #{work_out_name(name)}, one for me"
+  end
+
+  def self.work_out_name(name)
+    #raise "FoobaR"
+    name.non_existant_method
+  end
+end

--- a/test/fixtures/deep_exception/input/two_fer_test.rb
+++ b/test/fixtures/deep_exception/input/two_fer_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require_relative 'two_fer'
+
+# Common test data version: 1.2.0 4fc1acb
+class TwoFerTest < Minitest::Test
+
+  def test_no_name_given
+    assert_equal "One for you, one for me.", TwoFer.two_fer, %q{We tried running `TwoFer.two_fer` but received an unexpected result}
+  end
+end
+

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -25,7 +25,26 @@ class TestRunnerTest < Minitest::Test
     })
   end
 
-  def test_exception
+  def test_deep_exception
+    message = %q{
+NoMethodError: undefined method `non_existant_method' for nil:NilClass
+
+Traceback (most recent call first):
+    Line 8:in `work_out_name'
+    Line 3:in `two_fer'
+}.strip
+
+    assert_fixture(:deep_exception, {
+      status: :fail,
+      message: nil,
+      tests: [
+        {name: :test_no_name_given, status: :fail, message: message}
+      ]
+    })
+  end
+
+
+  def test_name_error_exception
     with_tmp_dir_for_fixture(:exception) do |input_dir, output_dir|
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal "error", actual["status"]


### PR DESCRIPTION
When tests fail with errors, this adds error messages like this:

```ruby
NoMethodError: undefined method `non_existant_method' for nil:NilClass

Traceback (most recent call first):
    Line 8:in `work_out_name'
    Line 3:in `two_fer'
```