### PR TITLE
Always return status 0 if the report gets written

### DIFF
--- a/bin/run.rb
+++ b/bin/run.rb
@@ -1,3 +1,14 @@
+# We want to override minitest's exit status
+# so we define this at the very top. We should
+# only override the exit status if we have a
+# report.json with some sensible things in.
+at_exit do
+  return unless MiniTest::ExercismReporter.instance
+  return unless MiniTest::ExercismReporter.instance.report_written?
+
+  exit 0
+end
+
 load File.expand_path('../../lib/test_runner.rb', __FILE__)
 
 TestRunner.run(ARGV[0], ARGV[1], ARGV[2])

--- a/lib/minitest_ext/exercism_reporter.rb
+++ b/lib/minitest_ext/exercism_reporter.rb
@@ -10,6 +10,10 @@ module MiniTest
       @instance = new(*args)
     end
 
+    def initialize
+      @report_written = false
+    end
+
     def start
     end
 
@@ -33,7 +37,7 @@ module MiniTest
     end
 
     def report
-      WriteReport.(path, status, tests: tests)
+      write_report(status, tests: tests)
     end
 
     def status
@@ -49,7 +53,11 @@ module MiniTest
           ExtractStandardExceptionErrorMessage.(e)
         end
 
-      WriteReport.(path, :error, message: message)
+      write_report(:error, message: message)
+    end
+
+    def report_written?
+      @report_written
     end
 
     private
@@ -58,6 +66,14 @@ module MiniTest
       @exercise = exercise
       @path = path
       @tests = []
+      @report_written = false
+    end
+
+    def write_report(status, tests: nil, message: nil)
+      return if report_written?
+
+      WriteReport.(path, status, tests: tests, message: message)
+      @report_written = true
     end
   end
 end

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -35,7 +35,7 @@ class TestRunner
         require test_file
       rescue StandardError, SyntaxError => e
         reporter.exception_raised!(e)
-        raise e
+        return
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,15 @@ class Minitest::Test
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal JSON.parse(expected.to_json), actual
     end
+    assert_test_run_exited_cleanly
+  end
+
+  def assert_test_run_exited_cleanly
+    assert_equal 0, $?.exitstatus
+  end
+
+  def refute_test_run_exited_cleanly
+    refute_equal 0, $?.exitstatus
   end
 
   def with_tmp_dir_for_fixture(fixture)
@@ -42,6 +51,6 @@ class Minitest::Test
     #system("bin/run.sh two_fer #{input_dir} #{output_dir}")
 
     # Main command
-    system("bin/run.sh two_fer #{input_dir} #{output_dir}", out: "/dev/null", err: "/dev/null")
+    system("bin/run.sh two_fer #{input_dir} #{output_dir}")#, out: "/dev/null", err: "/dev/null")
   end
 end

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -43,13 +43,14 @@ Traceback (most recent call first):
     })
   end
 
-
   def test_name_error_exception
     with_tmp_dir_for_fixture(:exception) do |input_dir, output_dir|
       actual = JSON.parse(File.read(output_dir / "results.json"))
       assert_equal "error", actual["status"]
 
       assert_equal %q{Line 3: undefined local variable or method `raise_an_error_because_i_am_a_random_method' for main:Object (NameError)}, actual['message']
+
+      assert_test_run_exited_cleanly
     end
   end
 
@@ -64,6 +65,8 @@ Line 3: syntax error, unexpected ',', expecting end-of-input
 EOS
 
       assert_equal expected.strip, actual['message']
+
+      assert_test_run_exited_cleanly
     end
   end
 
@@ -78,6 +81,15 @@ end,A stray comma
    ^
 EOS
       assert_equal expected.strip, actual['message']
+
+      assert_test_run_exited_cleanly
     end
+  end
+
+  def test_really_bad_things_exit_uncleanly
+    # I have no idea how to make this work, but
+    # it seems like a important test to have
+    #WriteReport.stubs(:new).raises("Something really bad!")
+    #refute_test_run_exited_cleanly
   end
 end


### PR DESCRIPTION
Minitest uses autorun to run when the program exits by hooking into the `at_exit` block. It then sets a status code based on whether its tests pass or fail. In contrast, we always want to return a exit code of 0 (success) if the report has written successfully, regardless of the contexts of the report.

This PR adds an `at_exit` block before minitest is required (and its hook is added), checks whether the report has been written, and then exits with 0 if it has been. If it hasn't been, then it carries does nothing to change the "normal" output.

I don't know how to write a test for the exit code 1 scenario.

This also returns rather than raises if there is a syntax error in a file being required, as this is more in line with what we actually mean.