### PR TITLE
Add 'debug' method for outputting user output

### DIFF
--- a/lib/ext/kernel.rb
+++ b/lib/ext/kernel.rb
@@ -1,0 +1,5 @@
+module Kernel
+  def debug(*args)
+    Minitest::ExercismReporter.instance.record_output(*args)
+  end
+end

--- a/lib/minitest_ext/exercism_reporter.rb
+++ b/lib/minitest_ext/exercism_reporter.rb
@@ -17,23 +17,12 @@ module MiniTest
     def start
     end
 
-    def record(result)
-      if result.failures.size == 0
-        test = {
-          status: :pass,
-          name: result.name,
-        }
-      else
-        message = result.error?? ExtractFailureErrorMessage.(result.failure) :
-                                 result.failure.to_s
-        test = {
-          status: :fail,
-          name: result.name,
-          message: message
-        }
-      end
+    def prerecord(*args)
+      reset_user_output
+    end
 
-      tests << test
+    def record(result)
+      tests << TestResult.new(result, user_output).to_h
     end
 
     def report
@@ -60,13 +49,19 @@ module MiniTest
       @report_written
     end
 
+    def record_output(*args)
+      user_output.puts(*args)
+    end
+
     private
-    attr_reader :exercise, :path, :results, :tests
+    attr_reader :exercise, :path, :results, :tests, :user_output
     def initialize(exercise, path)
       @exercise = exercise
       @path = path
       @tests = []
       @report_written = false
+
+      reset_user_output
     end
 
     def write_report(status, tests: nil, message: nil)
@@ -74,6 +69,51 @@ module MiniTest
 
       WriteReport.(path, status, tests: tests, message: message)
       @report_written = true
+    end
+
+    def reset_user_output
+      @user_output = StringIO.new
+    end
+
+    class TestResult
+      def initialize(result, output_stream)
+        @result = result
+        @output_stream = output_stream
+      end
+
+      def to_h
+        {}.tap do |hash|
+          hash[:name]    = result.name
+          hash[:status]  = status
+          hash[:output]  = output  if attach_output?
+          hash[:message] = message if attach_message?
+        end
+      end
+
+
+      private
+      attr_reader :result, :output_stream
+
+      def status
+        result.failures.size == 0 ? :pass : :fail
+      end
+
+      def attach_output?
+        status == :fail && output_stream.length > 0
+      end
+
+      def attach_message?
+        status == :fail
+      end
+
+      def message
+        result.error?? ExtractFailureErrorMessage.(result.failure) :
+                       result.failure.to_s
+      end
+
+      def output
+        output_stream.string
+      end
     end
   end
 end

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -14,6 +14,8 @@ require_relative "minitest_ext/exercism_plugin"
 require_relative "minitest_ext/exercism_reporter"
 require_relative "minitest_ext/minitest"
 
+require_relative "ext/kernel"
+
 class TestRunner
   def self.run(*args)
     new(*args).run

--- a/test/fixtures/fail/input/two_fer.rb
+++ b/test/fixtures/fail/input/two_fer.rb
@@ -1,5 +1,8 @@
 class TwoFer
   def self.two_fer(name="fred")
+    debug "The name is #{name}."
+    debug "Here's another line."
+
     "One for #{name}, one for me."
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,6 @@ class Minitest::Test
 end
 
 class Minitest::Test
-
   def assert_fixture(fixture, expected)
     with_tmp_dir_for_fixture(fixture) do |input_dir, output_dir|
       actual = JSON.parse(File.read(output_dir / "results.json"))
@@ -51,6 +50,6 @@ class Minitest::Test
     #system("bin/run.sh two_fer #{input_dir} #{output_dir}")
 
     # Main command
-    system("bin/run.sh two_fer #{input_dir} #{output_dir}")#, out: "/dev/null", err: "/dev/null")
+    system("bin/run.sh two_fer #{input_dir} #{output_dir}", out: "/dev/null", err: "/dev/null")
   end
 end

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -20,7 +20,12 @@ class TestRunnerTest < Minitest::Test
       tests: [
         {name: :test_a_name_given, status: :pass},
         {name: :test_another_name_given, status: :pass},
-        {name: :test_no_name_given, status: :fail, message: %Q{We tried running `TwoFer.two_fer` but received an unexpected result.\nExpected: \"One for you, one for me.\"\n  Actual: \"One for fred, one for me.\"}}
+        {
+          name: :test_no_name_given,
+          status: :fail,
+          message: %Q{We tried running `TwoFer.two_fer` but received an unexpected result.\nExpected: \"One for you, one for me.\"\n  Actual: \"One for fred, one for me.\"},
+          output: "The name is fred.\nHere's another line.\n"
+        }
       ]
     })
   end
@@ -63,7 +68,6 @@ Line 3: syntax error, unexpected ',', expecting end-of-input
 ,'This is meant to be a syntax...
 ^
 EOS
-
       assert_equal expected.strip, actual['message']
 
       assert_test_run_exited_cleanly


### PR DESCRIPTION
This adds a `debug` method, which can be used be users to output custom information. It only stores the information on failed tests.