### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+before_install:
+  - gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ansi (1.5.0)
-    builder (3.2.3)
     coderay (1.1.2)
     json (2.2.0)
     mandate (0.3.0)
     metaclass (0.0.4)
     method_source (0.9.2)
     minitest (5.11.3)
-    minitest-reporters (1.3.8)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     mocha (1.9.0)
       metaclass (~> 0.0.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (12.3.3)
-    ruby-progressbar (1.10.1)
 
 PLATFORMS
   ruby
@@ -29,10 +21,9 @@ DEPENDENCIES
   json
   mandate
   minitest (~> 5.11.3)
-  minitest-reporters
   mocha
   pry
   rake
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
Closes https://github.com/exercism/internal-wip/issues/39.

This is the [successful TravisCI build](https://travis-ci.org/exercism/ruby-test-runner/builds/655281676). I will leave it to you to configure the repo to require CI on merge, etc.