### PR TITLE
Add support for running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN mkdir /opt/test-runner
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner
 RUN bundle install
+
+ENTRYPOINT [ "sh", "bin/run.sh" ]


### PR DESCRIPTION
This allows one to do:

```
docker build -t exercism/ruby-test-runner
docker run -v /path/to/ruby/exercise:/solution <slug> exercism/ruby-test-runner /solution/ /solution/
```