### PR TITLE
Add cmd and expected to output

### DIFF
--- a/lib/extract_metadata.rb
+++ b/lib/extract_metadata.rb
@@ -1,0 +1,40 @@
+require 'rubocop/ast'
+require 'parser/current'
+
+# This class takes a test file, gets its AST, and 
+# looks for tests (def test_...). Each of these then
+# gets passed into the ExtractTestMetadata.() command
+# to get its metadata.
+class TestRunner
+  class ExtractMetadata < Parser::AST::Processor
+    include Mandate
+
+    initialize_with :filepath
+
+    def call
+      @filelines = File.readlines(filepath)
+      buffer = Parser::Source::Buffer.new('', source: filelines.join)
+      builder = RuboCop::AST::Builder.new
+      ast = Parser::CurrentRuby.new(builder).parse(buffer)
+
+      @tests = []
+
+      # Process starts an AST parse. Whenever a `def` node is hit
+      # the on_def method below is called. This is how AST parsing
+      # works via the parser gem.
+      process(ast)
+
+      # We've extacted all the tests, so now return them.
+      tests
+    end
+
+    def on_def(node)
+      return unless node.method_name.to_s.start_with?("test_")
+
+      tests << ExtractTestMetadata.(filelines, node) 
+    end
+
+    private
+    attr_reader :filelines, :tests
+  end
+end

--- a/lib/extract_test_metadata.rb
+++ b/lib/extract_test_metadata.rb
@@ -1,0 +1,145 @@
+class TestRunner
+  class ExtractTestMetadata < Parser::AST::Processor
+    include Mandate
+
+    initialize_with :filelines, :test_node
+
+    def call
+      @ignore_line_numbers = []
+
+      # Generate the data by taking a look at the AST.
+      # This method causes multiple calls of the on_send
+      # one for each time a method is invoked in the test class.
+      # For example, when we call assert, or skip
+      process(test_node)
+
+      # Now all the data is collected, just piece it together
+      # into a nice hash which can be merged into the test results
+      {
+        test: test_identifier,
+        name: test_name,
+        cmd: cmd,
+        expected: expected
+      }
+    end
+
+    def on_send(node)
+      # This method will get called for all the nodes that get called on
+      # the test class. We only care about a few of these so just leave
+      # the other ones alone.
+      return unless node.method_name.to_s.start_with?('assert') || 
+                    node.method_name.to_s.start_with?('refute') || 
+                    node.method_name == :skip
+
+      # If we've hit any of these lines, we ignore them from the output.
+      # We then add back the relevant bits below.
+      @ignore_line_numbers += (node.first_line..node.last_line).to_a
+
+
+      case node.method_name
+      when :skip
+        # Noop - All we want to do is ignore skip lines, 
+        # which has already happened above.
+      when :assert
+        handle_assert(node)
+      when :assert_equal
+        handle_assert_equal(node)
+      when :refute
+        handle_refute(node)
+      else
+        # TODO: Decide how to deal with assertions that
+        # we haven't coded for. This should only be a short-term
+        # problem as it's not hard to deal with all of them.
+        raise "Unknown assertion type"
+      end
+    end
+
+    private
+    attr_reader :expected, :assertion_cmd_part, :ignore_line_numbers
+
+    # For straight asserts, the expected value is always true
+    # and the cmd part of the code is always the first child
+    def handle_assert(node)
+      @assertion_cmd_part = code_for(node.child_nodes.first)
+      @expected = true
+    end
+
+    # Handling assert_equal means taking the first part as
+    # the expected, and the second part as the code for the cmd
+    def handle_assert_equal(node)
+      # Get the expected from the first arg
+      @expected = code_for(node.child_nodes.first)
+
+      # And get the actual from the second arg
+      @assertion_cmd_part = code_for(node.child_nodes[1])
+    end
+
+    # For straight refutes, the expected value is always false
+    # and the cmd part of the code is always the first child
+    def handle_refute(node)
+      @assertion_cmd_part = code_for(node.child_nodes.first)
+      @expected = false
+    end
+
+    memoize
+    def test_identifier
+      test_node.method_name.to_s
+    end
+
+    # TODO: Make this a bit prettier.
+    memoize
+    def test_name
+      test_node.method_name.to_s.gsub("test_", "")
+    end
+
+    # This builds up the command part. Simply put the algorithm is:
+    # - All the lines of codes that we haven't chosen to ignore
+    # - Plus an bits we've chosen to add back as the cmd part
+    memoize
+    def cmd
+      # Get the lines excluding the first (def) and last (end)
+      body_line_numbers = ((test_node.first_line + 1)..(test_node.last_line - 1))
+
+      # Map through those lines, skipping any that were
+      # part of assertionions
+      cmd = body_line_numbers.map { |idx|
+        code_for_line(idx) unless ignore_line_numbers.include?(idx)
+      }.compact.join("")
+
+      # Do this before we add the assertion, which
+      # will always be hard-left indented
+      cmd = clean_leading_whitespace(cmd)
+      cmd += assertion_cmd_part.rstrip
+    end
+
+    # Remove the minimum amount of leading whitespace
+    # from all lines
+    def clean_leading_whitespace(multiline)
+      min = multiline.lines.map {|line| line[/^\s*/].size}.min
+      multiline.gsub(/^\s{#{min}}/, '')
+    end
+
+    # This looks complex, but is very simple. It's extracting the 
+    # relevant part of the original code based on the AST position:
+    # (first_line:column .. last_line:last_column)
+    def code_for(node)
+      loc = node.loc
+
+      if loc.first_line == loc.last_line
+        line = code_for_line(loc.first_line)
+        line[loc.column...loc.last_column]
+      else
+        locs = (node.loc.first_line..node.last_line)
+        first  = code_for_line(locs.shift)[loc.column, -1]
+        last   = code_for_line(locs.pop)[0..loc.last_column]
+        [first, *locs, last].compact.join("\n").rtrim
+      end
+    end
+
+    # The parser returns 1-indexed line numbers. This
+    # function retreives them based on their 0-based equiv.
+    def code_for_line(one_indexed_idx)
+      filelines[one_indexed_idx - 1]
+    end
+  end
+end

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -5,6 +5,8 @@ gem 'minitest'
 require "minitest/autorun"
 
 require_relative "write_report"
+require_relative "extract_metadata"
+require_relative "extract_test_metadata"
 
 require_relative "minitest_ext/extract_standard_exception_error_message"
 require_relative "minitest_ext/extract_syntax_exception_error_message"
@@ -33,6 +35,8 @@ class TestRunner
     Minitest::Test.use_order_dependent_tests!
 
     Dir.glob(input_path + "/*_test.rb").sort.each do |test_file|
+      reporter.metadata = ExtractMetadata.(test_file)
+
       begin
         require test_file
       rescue StandardError, SyntaxError => e

--- a/lib/write_report.rb
+++ b/lib/write_report.rb
@@ -1,24 +1,26 @@
-class WriteReport
-  include Mandate
+class TestRunner
+  class WriteReport
+    include Mandate
 
-  def initialize(path, status, tests: [], message: nil)
-    @path = path
-    @status = status
-    @tests = tests
-    @message = message
-  end
+    def initialize(path, status, tests: [], message: nil)
+      @path = path
+      @status = status
+      @tests = tests
+      @message = message
+    end
 
-  def call
-    File.write("#{path}/results.json", json)
-  end
+    def call
+      File.write("#{path}/results.json", json)
+    end
 
-  private
-  attr_reader :path, :status, :message, :tests
-  def json
-    {
-      status: status,
-      message: message,
-      tests: tests
-    }.to_json
+    private
+    attr_reader :path, :status, :message, :tests
+    def json
+      {
+        status: status,
+        message: message,
+        tests: tests
+      }.to_json
+    end
   end
 end

--- a/test/attacks_test.rb
+++ b/test/attacks_test.rb
@@ -2,17 +2,21 @@ require "test_helper"
 
 class AttacksTest < Minitest::Test
   def test_large_output_is_truncated
-    assert_fixture(:attack_large_output, {
-                     status: :fail,
-                     message: nil,
-                     tests: [
-                       {
-                         name: :test_no_name_given,
-                         status: :fail,
-                         output: %(#{Array.new(500) { 'a' }.join}\n\n...Output was truncated. Please limit to 500 chars...),
-                         message: "Expected: \"One for you, one for me.\"\n  Actual: false"
-                       }
-                     ]
-                   })
+    assert_fixture(
+      :attack_large_output, {
+        status: :fail,
+        message: nil,
+        tests: [
+          {
+            name: :no_name_given,
+            cmd: "TwoFer.two_fer",
+            expected: '"One for you, one for me."',
+            status: :fail,
+            output: %(#{Array.new(500) { 'a' }.join}\n\n...Output was truncated. Please limit to 500 chars...),
+            message: "Expected: \"One for you, one for me.\"\n  Actual: false"
+          }
+        ]
+      }
+    )
   end
 end

--- a/test/extract_metadata_test.rb
+++ b/test/extract_metadata_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require 'test_runner'
+
+class ExtractMetadataTest < Minitest::Test
+  def test_assert
+    expected = [{
+      test: "test_assert_works_properly",
+      name: "assert_works_properly",
+      cmd: "something = \"Something\"\nsomething.present?",
+      expected: true
+    }]
+    
+    actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/assertions/assert.rb", __dir__))
+    assert_equal expected, actual
+  end
+
+  def test_refute
+    expected = [{
+      test: "test_refute_works_properly",
+      name: "refute_works_properly",
+      cmd: "something = \"Something\"\nsomething.nil?",
+      expected: false
+    }]
+    
+    actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/assertions/refute.rb", __dir__))
+    assert_equal expected, actual
+  end
+
+  def test_assert_equal
+    expected = [{
+      test: "test_assert_equal_works_properly",
+      name: "assert_equal_works_properly",
+      cmd: "some_result = TwoFer.two_fer\nsome_result",
+      expected: '"One for you, one for me."'
+    }]
+    
+    actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/assertions/assert_equal.rb", __dir__))
+    assert_equal expected, actual
+  end
+
+  def test_no_skips
+    expected = [{
+      test: "test_skip_works_properly",
+      name: "skip_works_properly",
+      cmd: "something = \"Something\"\nsomething.present?",
+      expected: true
+    }]
+    
+    actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/assertions/skip.rb", __dir__))
+    assert_equal expected, actual
+  end
+end

--- a/test/fixtures/assertions/assert.rb
+++ b/test/fixtures/assertions/assert.rb
@@ -1,0 +1,6 @@
+class SomeTest < Minitest::Test
+  def test_assert_works_properly
+    something = "Something"
+    assert something.present?
+  end
+end

--- a/test/fixtures/assertions/assert_equal.rb
+++ b/test/fixtures/assertions/assert_equal.rb
@@ -1,0 +1,6 @@
+class SomeTest < Minitest::Test
+  def test_assert_equal_works_properly
+    some_result = TwoFer.two_fer
+    assert_equal "One for you, one for me.", some_result
+  end
+end

--- a/test/fixtures/assertions/refute.rb
+++ b/test/fixtures/assertions/refute.rb
@@ -1,0 +1,6 @@
+class SomeTest < Minitest::Test
+  def test_refute_works_properly
+    something = "Something"
+    refute something.nil?
+  end
+end

--- a/test/fixtures/assertions/skip.rb
+++ b/test/fixtures/assertions/skip.rb
@@ -1,0 +1,8 @@
+class SomeTest < Minitest::Test
+  def test_skip_works_properly
+    skip
+    something = "Something"
+    assert something.present?
+  end
+end
+

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -2,40 +2,63 @@ require "test_helper"
 
 class TestRunnerTest < Minitest::Test
   def test_pass
-    assert_fixture(:pass, {
-                     status: :pass,
-                     message: nil,
-                     tests: [
-                       { name: :test_a_name_given, status: :pass },
-                       { name: :test_another_name_given, status: :pass },
-                       { name: :test_no_name_given, status: :pass }
-                     ]
-                   })
+    assert_fixture(
+      :pass,
+      {
+        status: :pass,
+        message: nil,
+        tests: [
+          {
+            name: :a_name_given, status: :pass,
+            cmd: 'TwoFer.two_fer("Alice")',
+            expected: '"One for Alice, one for me."'
+          },
+          {
+            name: :another_name_given, status: :pass,
+            cmd: 'TwoFer.two_fer("Bob")',
+            expected: '"One for Bob, one for me."'
+          },
+          {
+            name: :no_name_given, status: :pass,
+            cmd: "# skip\nTwoFer.two_fer",
+            expected: '"One for you, one for me."'
+          }
+        ]
+      }
+    )
   end
 
   def test_fail
-    assert_fixture(:fail, {
-                     status: :fail,
-                     message: nil,
-                     tests: [
-                       {
-                         name: :test_a_name_given,
-                         status: :pass,
-                         output: "The name is Alice.\nHere's another line.\n"
-                       },
-                       {
-                         name: :test_another_name_given,
-                         status: :pass,
-                         output: "The name is Bob.\nHere's another line.\n"
-                       },
-                       {
-                         name: :test_no_name_given,
-                         status: :fail,
-                         message: %(We tried running `TwoFer.two_fer` but received an unexpected result.\nExpected: \"One for you, one for me.\"\n  Actual: \"One for fred, one for me.\"),
-                         output: "The name is fred.\nHere's another line.\n"
-                       }
-                     ]
-                   })
+    assert_fixture(
+      :fail, {
+        status: :fail,
+        message: nil,
+        tests: [
+          {
+            name: :a_name_given,
+            cmd: 'TwoFer.two_fer("Alice")',
+            expected: '"One for Alice, one for me."',
+            status: :pass,
+            output: "The name is Alice.\nHere's another line.\n"
+          },
+          {
+            name: :another_name_given,
+            cmd: 'TwoFer.two_fer("Bob")',
+            expected: '"One for Bob, one for me."',
+            status: :pass,
+            output: "The name is Bob.\nHere's another line.\n"
+          },
+          {
+            name: :no_name_given,
+            cmd: "# skip\nTwoFer.two_fer",
+            expected: '"One for you, one for me."',
+            status: :fail,
+            message: %(We tried running `TwoFer.two_fer` but received an unexpected result.\nExpected: \"One for you, one for me.\"\n  Actual: \"One for fred, one for me.\"),
+            output: "The name is fred.\nHere's another line.\n"
+          }
+        ]
+      }
+    )
   end
 
   def test_deep_exception
@@ -51,7 +74,13 @@ Traceback (most recent call first):
                      status: :fail,
                      message: nil,
                      tests: [
-                       { name: :test_no_name_given, status: :error, message: message }
+                       {
+                         name: :no_name_given,
+                         status: :error,
+                         cmd: 'TwoFer.two_fer',
+                         expected: '"One for you, one for me."',
+                         message: message
+                       }
                      ]
                    })
   end


### PR DESCRIPTION
This PR adds the `cmd` and `expected` fields automatically to the Ruby Test runner.

It currently checks for `assert`, `refute` and `assert_equal`, but other assertion types are now trivial to add (10mins each).

The methodology is quite straight-forward.
- Extract the AST of the testfile.
- Find each test case (looking for when a method with `test_` is defined, as per the Ruby convention).
- For each of those test methods, look for any lines that need special treatment (e.g. `assert`, `reject`, `skip`)
- Handle each of those lines, and add their line numbers to a list of lines to remove.
- Take the original lines of code, minus the special lines, add on any extra bits from the assert handling, and output cmd.
- The expected is always one side of the assert (or will be a string e.g. "Larger than X" later on)

---

I wanted to do this because we've been exploring various solutions and I wanted to understand how easy or hard this **really** was for me to do in Ruby, rather than just guessing at how hard I thought it would be. My conclusion is that it was pretty straight-forward. If I was more fluent with ASTs this would have been a one-hour job. In total it took me two hours to do. 

Other languages might find their AST support worse, or individuals might find the ASTs harder to work with, so I understand that this is a Ruby/me specific benchmark. But my opinion is that this approach has been much easier than adding comments to all the test files and much simpler than trying to parse those, etc.