### PR TITLE
Ensure identical diffs on all systems and shells

### DIFF
--- a/lib/extract_test_metadata.rb
+++ b/lib/extract_test_metadata.rb
@@ -43,7 +43,7 @@ class TestRunner
     memoize
     def test_name
       test_node.method_name.to_s.gsub("test_", "").
-                                 gsub("_", " ").capitalize
+        tr("_", " ").capitalize
     end
 
     # This builds up the command part. Simply put the algorithm is:

--- a/lib/minitest_ext/minitest.rb
+++ b/lib/minitest_ext/minitest.rb
@@ -1,9 +1,16 @@
 module Minitest
   module Assertions
     undef_method :skip if method_defined? :skip
+    undef_method :diff if method_defined? :diff
 
     def skip
       # Noop
+    end
+
+    # override any fancy diffing tools that might be available on the OS
+    # so that everyone who runs the test runner gets the same simple diff
+    def diff(exp, act)
+      "Expected: #{exp.inspect}\n  Actual: #{act.inspect}"
     end
   end
 


### PR DESCRIPTION
I run into this problem that the unit tests were failing for me even though on CI they would pass. It was related to the diff output of minitest.
```
$ bundle exec rake test
Run options: --seed 40333
# Running:
......FF...
Fabulous run in 3.595423s, 3.0594 runs/s, 5.0064 assertions/s.
  1) Failure:
TestRunnerTest#test_fail [/Users/angelika/Documents/exercism/ruby-test-runner/test/test_runner_test.rb:33]:
--- expected
+++ actual
@@ -2,7 +2,12 @@
 Here's another line.
 "}, {"name"=>"Another name given", "test_code"=>"assert_equal \"One for Bob, one for me.\", TwoFer.two_fer(\"Bob\")", "status"=>"pass", "output"=>"The name is Bob.
 Here's another line.
-"}, {"name"=>"No name given", "test_code"=>"assert_equal \"One for you, one for me.\", TwoFer.two_fer", "status"=>"fail", "message"=>"Expected: \"One for you, one for me.\"
-  Actual: \"One for fred, one for me.\"", "output"=>"The name is fred.
+"}, {"name"=>"No name given", "test_code"=>"assert_equal \"One for you, one for me.\", TwoFer.two_fer", "status"=>"fail", "output"=>"The name is fred.
 Here's another line.
+", "message"=>"--- expected
++++ actual
+@@ -1,2 +1,2 @@
+ # encoding: UTF-8
+-\"One for you, one for me.\"
++\"One for fred, one for me.\"
 "}]}
  2) Failure:
AttacksTest#test_large_output_is_truncated [/Users/angelika/Documents/exercism/ruby-test-runner/test/attacks_test.rb:5]:
--- expected
+++ actual
@@ -1,4 +1,9 @@
 {"version"=>2, "status"=>"fail", "message"=>nil, "tests"=>[{"name"=>"No name given", "test_code"=>"assert_equal \"One for you, one for me.\", TwoFer.two_fer", "status"=>"fail", "output"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-...Output was truncated. Please limit to 500 chars...", "message"=>"Expected: \"One for you, one for me.\"
-  Actual: false"}]}
+...Output was truncated. Please limit to 500 chars...", "message"=>"--- expected
++++ actual
+@@ -1,2 +1 @@
+-# encoding: UTF-8
+-\"One for you, one for me.\"
++false
+"}]}
11 runs, 18 assertions, 2 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
/Users/angelika/.asdf/installs/ruby/2.6.6/bin/bundle:23:in `load'
/Users/angelika/.asdf/installs/ruby/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

Turns out Minitest has a lot of conditions for what the test output will be:
1. Depending on the OS and availability of scripts, a diffing tool is chosen: https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L32-L41
2. Depending on... the shell? its env? string encoding might or might not be printed: https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L132-L141

I hit both of those issues.

To solve this, I'm overwriting the method used for printing the diff between the expected and actual values.