### PR TITLE
#37 - Upgrade to version 3 spec

### DIFF
--- a/lib/minitest_ext/exercism_reporter.rb
+++ b/lib/minitest_ext/exercism_reporter.rb
@@ -93,6 +93,7 @@ module Minitest
           hash[:status]    = status
           hash[:output]    = output  if attach_output?
           hash[:message]   = message if attach_message?
+          hash[:task_id]   = metadata[:task_id]
         end
       end
 

--- a/lib/write_report.rb
+++ b/lib/write_report.rb
@@ -18,7 +18,7 @@ class TestRunner
 
     def json
       {
-        version: 2,
+        version: 3,
         status: status,
         message: message,
         tests: tests

--- a/test/attacks_test.rb
+++ b/test/attacks_test.rb
@@ -4,7 +4,7 @@ class AttacksTest < Minitest::Test
   def test_large_output_is_truncated
     assert_fixture(
       :attack_large_output, {
-        version: 2,
+        version: 3,
         status: :fail,
         message: nil,
         tests: [
@@ -13,7 +13,8 @@ class AttacksTest < Minitest::Test
             test_code: 'assert_equal "One for you, one for me.", TwoFer.two_fer',
             status: :fail,
             output: %(#{Array.new(500) { 'a' }.join}\n\n...Output was truncated. Please limit to 500 chars...),
-            message: "Expected: \"One for you, one for me.\"\n  Actual: false"
+            message: "Expected: \"One for you, one for me.\"\n  Actual: false",
+            task_id: nil
           }
         ]
       }

--- a/test/extract_metadata_test.rb
+++ b/test/extract_metadata_test.rb
@@ -7,7 +7,8 @@ class ExtractMetadataTest < Minitest::Test
       test: "test_assert_equal_works_properly",
       name: "Assert equal works properly",
       test_code: %(some_result = TwoFer.two_fer\nassert_equal "One for you, one for me.", some_result),
-      index: 0
+      index: 0,
+      task_id: 123
     }]
 
     actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/metadata/assert_equal.rb", __dir__))
@@ -19,7 +20,8 @@ class ExtractMetadataTest < Minitest::Test
       test: "test_skip_works_properly",
       name: "Skip works properly",
       test_code: "something = \"Something\"\nassert something.present?",
-      index: 0
+      index: 0,
+      task_id: 456
     }]
 
     actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/metadata/skip.rb", __dir__))
@@ -31,7 +33,8 @@ class ExtractMetadataTest < Minitest::Test
       test: "test_skip_works_properly",
       name: "Skip works properly",
       test_code: "something = \"Something\"\nassert something.present?",
-      index: 0
+      index: 0,
+      task_id: 789
     }]
 
     actual = TestRunner::ExtractMetadata.(File.expand_path("fixtures/metadata/skip_comment.rb", __dir__))
@@ -44,25 +47,29 @@ class ExtractMetadataTest < Minitest::Test
         test: "test_zebra",
         name: "Zebra",
         test_code: %(some_result = TwoFer.two_fer("zebra")\nassert_equal "One for you, one for zebra.", some_result),
-        index: 0
+        index: 0,
+        task_id: 789
       },
       {
         test: "test_anaconda",
         name: "Anaconda",
         test_code: %(some_result = TwoFer.two_fer("anaconda")\nassert_equal "One for you, one for anaconda.", some_result),
-        index: 1
+        index: 1,
+        task_id: nil
       },
       {
         test: "test_gorilla",
         name: "Gorilla",
         test_code: %(some_result = TwoFer.two_fer("gorilla")\nassert_equal "One for you, one for gorilla.", some_result),
-        index: 2
+        index: 2,
+        task_id: nil
       },
       {
         test: "test_boa",
         name: "Boa",
         test_code: %(some_result = TwoFer.two_fer("boa")\nassert_equal "One for you, one for boa.", some_result),
-        index: 3
+        index: 3,
+        task_id: nil
       }
     ]
 

--- a/test/fixtures/metadata/assert_equal.rb
+++ b/test/fixtures/metadata/assert_equal.rb
@@ -1,5 +1,6 @@
 class SomeTest < Minitest::Test
   def test_assert_equal_works_properly
+    ### task_id: 123
     some_result = TwoFer.two_fer
     assert_equal "One for you, one for me.", some_result
   end

--- a/test/fixtures/metadata/indices.rb
+++ b/test/fixtures/metadata/indices.rb
@@ -1,5 +1,6 @@
 class SomeTest < Minitest::Test
   def test_zebra
+    ### task_id: 789
     some_result = TwoFer.two_fer("zebra")
     assert_equal "One for you, one for zebra.", some_result
   end

--- a/test/fixtures/metadata/skip.rb
+++ b/test/fixtures/metadata/skip.rb
@@ -1,5 +1,6 @@
 class SomeTest < Minitest::Test
   def test_skip_works_properly
+    ### task_id: 456
     skip
     something = "Something"
     assert something.present?

--- a/test/fixtures/metadata/skip_comment.rb
+++ b/test/fixtures/metadata/skip_comment.rb
@@ -1,5 +1,6 @@
 class SomeTest < Minitest::Test
   def test_skip_works_properly
+    ### task_id: 789
     #skip
     # skip
     something = "Something"

--- a/test/test_runner_test.rb
+++ b/test/test_runner_test.rb
@@ -5,24 +5,27 @@ class TestRunnerTest < Minitest::Test
     assert_fixture(
       :pass,
       {
-        version: 2,
+        version: 3,
         status: :pass,
         message: nil,
         tests: [
           {
             name: "No name given",
             status: :pass,
-            test_code: %(assert_equal "One for you, one for me.", TwoFer.two_fer)
+            test_code: %(assert_equal "One for you, one for me.", TwoFer.two_fer),
+            task_id: nil
           },
           {
             name: 'A name given',
             test_code: 'assert_equal "One for Alice, one for me.", TwoFer.two_fer("Alice")',
-            status: :pass
+            status: :pass,
+            task_id: nil
           },
           {
             name: "Another name given",
             status: :pass,
-            test_code: 'assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")'
+            test_code: 'assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")',
+            task_id: nil
           }
         ]
       }
@@ -33,19 +36,21 @@ class TestRunnerTest < Minitest::Test
     assert_fixture(
       :pass_ruby_3_syntax,
       {
-        version: 2,
+        version: 3,
         status: :pass,
         message: nil,
         tests: [
           {
             name: "Rightward assign",
             status: :pass,
-            test_code: %(assert_equal Ruby3Syntax.rightward_assign, 'is fun')
+            test_code: %(assert_equal Ruby3Syntax.rightward_assign, 'is fun'),
+            task_id: nil
           },
           {
             name: "Endless method def",
             status: :pass,
-            test_code: %(assert_equal Ruby3Syntax.endless_methods, 'are fun')
+            test_code: %(assert_equal Ruby3Syntax.endless_methods, 'are fun'),
+            task_id: nil
           }
         ]
       }
@@ -55,7 +60,7 @@ class TestRunnerTest < Minitest::Test
   def test_fail
     assert_fixture(
       :fail, {
-        version: 2,
+        version: 3,
         status: :fail,
         message: nil,
         tests: [
@@ -64,19 +69,22 @@ class TestRunnerTest < Minitest::Test
             test_code: %(assert_equal "One for you, one for me.", TwoFer.two_fer),
             status: :fail,
             message: %(Expected: \"One for you, one for me.\"\n  Actual: \"One for fred, one for me.\"),
-            output: "The name is fred.\nHere's another line.\n"
+            output: "The name is fred.\nHere's another line.\n",
+            task_id: nil
           },
           {
             name: "A name given",
             test_code: 'assert_equal "One for Alice, one for me.", TwoFer.two_fer("Alice")',
             status: :pass,
-            output: "The name is Alice.\nHere's another line.\n"
+            output: "The name is Alice.\nHere's another line.\n",
+            task_id: nil
           },
           {
             name: "Another name given",
             test_code: 'assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")',
             status: :pass,
-            output: "The name is Bob.\nHere's another line.\n"
+            output: "The name is Bob.\nHere's another line.\n",
+            task_id: nil
           }
         ]
       }
@@ -95,7 +103,7 @@ Traceback (most recent call first):
     assert_fixture(
       :deep_exception,
       {
-        version: 2,
+        version: 3,
         status: :fail,
         message: nil,
         tests: [
@@ -103,7 +111,8 @@ Traceback (most recent call first):
             name: "No name given",
             test_code: 'assert_equal "One for you, one for me.", TwoFer.two_fer',
             status: :error,
-            message: message
+            message: message,
+            task_id: nil
           }
         ]
       }


### PR DESCRIPTION
closes #37 

Test file
```
require 'minitest/autorun'
require_relative 'hamming'

# Common test data version: 2.2.0 4c453c8
class HammingTest < Minitest::Test
  def test_empty_strands
    ### task_id: 1
    # skip
    assert_equal 0, Hamming.compute('', '')
  end

  def test_single_letter_identical_strands
    ### task_id: 2
    # skip
    assert_equal 0, Hamming.compute('A', 'A')
  end

  def test_single_letter_different_strands
    ### task_id: 3
    # skip
    assert_equal 1, Hamming.compute('G', 'T')
  end
end
```

results.json
```
{
  "version": 3,
  "message": null,
  "status": "pass",
  "tests": [
    {
      "name": "Empty strands",
      "status": "pass",
      "task_id": 1,
      "test_code": "assert_equal 0, Hamming.compute('', '')"
    },
    {
      "name": "Single letter identical strands",
      "status": "pass",
      "task_id": 2,
      "test_code": "assert_equal 0, Hamming.compute('A', 'A')"
    },
    {
      "name": "Single letter different strands",
      "status": "pass",
      "task_id": 3,
      "test_code": "assert_equal 1, Hamming.compute('G', 'T')"
    }
  ]
}
```