### PR TITLE
Install the current Bundler in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk upgrade && \
 
 COPY Gemfile Gemfile.lock .
 
-RUN gem install bundler && \
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" && \
     bundle config set without 'development test' && \
     bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk upgrade && \
 
 COPY Gemfile Gemfile.lock .
 
-RUN gem install bundler:2.4.18 && \
+RUN gem install bundler && \
     bundle config set without 'development test' && \
     bundle install
 


### PR DESCRIPTION
In `Dockerfile`, we have been specifying the exact Bundler version to install. This is no longer necessary.

This commit updates `Dockerfile` to install the current version of Bundler. Bundler will then take care of setting up the correct version to use.

Ref:
- https://github.com/exercism/ruby/pull/1635#issuecomment-1945522414