### PR TITLE
Fix warning for mutex_m standard lib changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby '3.3.0'
 
 gem "mandate", "~> 1.0.0"
 gem 'rake'
+gem 'mutex_m'
 gem 'json', '~> 2.6.1'
 gem 'minitest', '~> 5.11.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     minitest (5.11.3)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
+    mutex_m (0.2.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -59,6 +60,7 @@ DEPENDENCIES
   mandate (~> 1.0.0)
   minitest (~> 5.11.3)
   mocha
+  mutex_m
   parser
   pry
   rake


### PR DESCRIPTION
> gems/ruby-3.3.0/gems/minitest-5.11.3/lib/minitest.rb:3: warning: mutex_m
> was loaded from the standard library, but will no longer be part of the
> default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec